### PR TITLE
Make the purecloud tap runnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-config.json
+config.*json
+target.*json
+catalog.*json
 persist.json
 env
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import os.path
 
 setup(name='tap-purecloud',
-      version='0.0.6',
+      version='0.0.7',
       description='Singer.io tap for extracting data from the Genesys Purecloud API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='tap-purecloud',
           'backoff==1.3.2',
           'requests==2.20.0',
           'python-dateutil==2.6.0',
+          'pytz==2020.5', # Pin to fuji
           'PureCloudPlatformApiSdk==0.45.1.101',
           'PureCloudPlatformClientV2==26.0.0',
           'websockets==5.0.1'

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -35,6 +35,12 @@ BASE_PURECLOUD_AUTH_HOST = 'https://login.{domain}'
 BASE_PURECLOUD_API_HOST = 'https://api.{domain}'
 DEFAULT_SCHEDULE_LOOKAHEAD_WEEKS = 5
 
+REQUIRED_CONFIG_KEYS = [
+    'start_date',
+    'domain',
+    'client_id',
+    'client_secret',
+]
 
 def giveup(error):
     logger.warning("Encountered an error while syncing")
@@ -583,62 +589,6 @@ def sync_user_details(config):
 
         first_page = False
 
-
-def validate_config(config):
-    required_keys = ['domain', 'client_id', 'client_secret', 'start_date']
-    missing_keys = []
-    null_keys = []
-    has_errors = False
-
-    for required_key in required_keys:
-        if required_key not in config:
-            missing_keys.append(required_key)
-
-        elif config.get(required_key) is None:
-            null_keys.append(required_key)
-
-    if len(missing_keys) > 0:
-        logger.fatal("Config is missing keys: {}"
-                     .format(", ".join(missing_keys)))
-        has_errors = True
-
-    if len(null_keys) > 0:
-        logger.fatal("Config has null keys: {}"
-                     .format(", ".join(null_keys)))
-        has_errors = True
-
-    if has_errors:
-        raise RuntimeError
-
-
-def load_config(filename):
-    config = {}
-
-    try:
-        with open(filename) as f:
-            config = json.load(f)
-    except Exception as e:
-        logger.fatal("Failed to decode config file. Is it valid json?")
-        logger.fatal(e)
-        raise RuntimeError
-
-    validate_config(config)
-
-    return config
-
-
-def load_state(filename):
-    if filename is None:
-        return {}
-
-    try:
-        with open(filename) as f:
-            return json.load(f)
-    except:
-        logger.fatal("Failed to decode state file. Is it valid json?")
-        raise RuntimeError
-
-
 def parse_input_date(date_string):
     return parse(date_string)
 
@@ -646,8 +596,8 @@ def parse_input_date(date_string):
 def do_sync(args):
     logger.info("Starting sync.")
 
-    config = load_config(args.config)
-    state = load_state(args.state)
+    config: dict = args.config
+    state: dict = args.state
 
     # grab start date from state file. If not found
     # default to value in config file
@@ -690,24 +640,13 @@ def do_sync(args):
 
 @utils.handle_top_exception(logger)
 def main():
-    parser = argparse.ArgumentParser()
+    parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-    parser.add_argument(
-        '-c', '--config', help='Config file', required=True)
-    parser.add_argument(
-        '-s', '--state', help='State file')
-    parser.add_argument('-d', '--discover', action='store_true',
-        help='Do schema discovery')
-    parser.add_argument(
-        '--catalog',
-        help='Catalog file')
-
-    args = parser.parse_args()
-    if args.discover:
+    if parsed_args.discover:
+        # TODO: Include a method to discover catalogs
         pass
     else:
-        do_sync(args)
-
+        do_sync(parsed_args)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
# Description of change
Currently the tap is not runnable based on the commands that we typically use to invoke a singer tap. 

ex.
```
(venv) ➜  tap-purecloud git:(master) ✗ tap-purecloud --config config.json --discover > discovered_catalog.json
usage: tap-purecloud [-h] -c CONFIG [-s STATE]
tap-purecloud: error: unrecognized arguments: --discover
```

This is because the purecloud tap is running an old version of singer that doesn't use the discover command. This PR at least makes it runnable by accepting the `--discover` and `--catalog` args.

Note that we might run into some problems because there is no catalog generation. The catalog is currently hardcoded in `tap_purecloud/schemas.py`. We may need to rewrite this tap using the singer-tap-template
