### PR TITLE
Upgrade PureCloudPlatformClientV2 to 151.0.0 from 26.0.0, remove PureCloudPlatformApiSdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ setup(name='tap-purecloud',
           'backoff==1.8.0',
           'requests==2.20.0',
           'python-dateutil==2.6.0',
-          'PureCloudPlatformApiSdk==0.45.1.101',
-          'PureCloudPlatformClientV2==26.0.0',
+          'PureCloudPlatformClientV2==64.0.1',
           'websockets==5.0.1'
       ],
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-purecloud',
-      version='0.0.8',
+      version='0.0.9',
       description='Singer.io tap for extracting data from the Genesys Purecloud API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',
@@ -12,10 +12,12 @@ setup(name='tap-purecloud',
       install_requires=[
           'singer-python==5.12.0',
           'backoff==1.8.0',
-          'requests==2.20.0',
+          'requests==2.25.1',
           'python-dateutil==2.6.0',
-          'PureCloudPlatformClientV2==64.0.1',
-          'websockets==5.0.1'
+          'PureCloudPlatformClientV2==151.0.0',
+          # Using Python 3.7 so upgrade from 5.0.1 to 6.0.0
+          # See https://github.com/aaugustin/websockets/issues/432
+          'websockets==6.0.0'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -32,7 +32,7 @@ from PureCloudPlatformClientV2.api_client import ApiClient
 from PureCloudPlatformClientV2.rest import ApiException as PureCloudApiException
 
 import tap_purecloud.schemas as schemas
-import tap_purecloud.websocket_helper
+from tap_purecloud.websocket_helper import get_historical_adherence
 from tap_purecloud.util import safe_json_serialize_deserialize
 
 logger = singer.get_logger()
@@ -336,7 +336,7 @@ def sync_user_schedules(api_instance: WorkforceManagementApi, config, unit_id, u
 def sync_wfm_historical_adherence(api_instance: WorkforceManagementApi, config, unit_id, users, body):
     # The ol' Python pass-by-reference
     result_reference = {}
-    wfm_notifcation_thread = tap_purecloud.websocket_helper.get_historical_adherence(config, result_reference)
+    wfm_notifcation_thread = get_historical_adherence(api_instance, config, result_reference)
 
     # give the webhook a chance to get settled
     logger.info("Waiting for websocket to settle")

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -137,7 +137,7 @@ def fetch_all_analytics_records(get_records, body, entity_name, max_pages=None):
     api_function_params = {}
 
     body.paging = {
-        "pageSize": 100,
+        "pageSize": 1000, # Increase the page size since there can be lots of records
         "pageNumber": 1
     }
 
@@ -336,7 +336,8 @@ def sync_user_schedules(api_instance: WorkforceManagementApi, config, unit_id, u
 def sync_wfm_historical_adherence(api_instance: WorkforceManagementApi, config, unit_id, users, body):
     # The ol' Python pass-by-reference
     result_reference = {}
-    wfm_notifcation_thread = get_historical_adherence(api_instance, config, result_reference)
+    api_client = api_instance.api_client
+    wfm_notifcation_thread = get_historical_adherence(api_client, config, result_reference)
 
     # give the webhook a chance to get settled
     logger.info("Waiting for websocket to settle")
@@ -371,7 +372,7 @@ def get_user_unit_mapping(users):
 
 def sync_historical_adherence(api_instance: WorkforceManagementApi, config, unit_id, users, first_page):
 
-    sync_date: 'datetime.date' = config['start_date']
+    sync_date: 'datetime.date' = config['_sync_date']
 
     end_date: 'datetime.date' = datetime.date.today()
     incr = datetime.timedelta(days=1)
@@ -420,7 +421,7 @@ def sync_management_units(api_client: ApiClient, config):
 
         # don't allow args here
         getter = lambda *args, **kwargs: api_instance.get_workforcemanagement_managementunit_users(unit_id)
-        gen_users = fetch_all_records(getter, 'entities', FakeBody(), max_pages=1)
+        gen_users = fetch_all_records(getter, 'entities', FakeBody(page_size=1000), max_pages=1)
         users = stream_results(gen_users, handle_mgmt_users(unit_id), 'management_unit_users', schemas.management_unit_users, ['user_id', 'management_unit_id'], first_page)
 
         user_ids = [user['user_id'] for user in users]

--- a/tap_purecloud/util.py
+++ b/tap_purecloud/util.py
@@ -1,0 +1,13 @@
+import json
+
+
+def safe_json_serialize_deserialize(data: any, **kwargs) -> dict:
+    """
+    Utility function that safely serializes unserializable fields in
+    'data' as str and returns back the deserialized version
+
+    Typically useful for serializing datetime.datetime or datetime.date
+    Properly handle values if particular values for a key look incorrect
+    """
+    json_string = json.dumps(data, default=str, **kwargs)
+    return json.loads(json_string)

--- a/tap_purecloud/websocket_helper.py
+++ b/tap_purecloud/websocket_helper.py
@@ -32,8 +32,7 @@ async def get_websocket_msg(uri):
         raise RuntimeError("Did not find expected message")
 
 
-def get_historical_adherence(api_instance, config, result_reference):
-    api_client = api_instance.api_client
+def get_historical_adherence(api_client, config, result_reference):
     notif_api_instance = NotificationsApi(api_client)
     api_response = notif_api_instance.post_notifications_channels()
 
@@ -50,7 +49,7 @@ def get_historical_adherence(api_instance, config, result_reference):
         asyncio.set_event_loop(loop)
         func = get_websocket_msg(websocket_uri)
         val = loop.run_until_complete(func)
-        result_reference.update(val)
+        res.update(val)
 
     websocket_uri = api_response.connect_uri
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
Update accordingly and include type hints

Removed PureCloudPlatformApiSdk since it hasn't been updated in 5+ years https://pypi.org/project/PureCloudPlatformApiSdk/#history This was required since some APIs, notably `RoutingApi` and `WorkforceManagementApi` were still throwing 403s after changing the permissions.

```python
import PureCloudPlatformClientV2

host = 'https://api.somedomain'
# This get_client_credentials_token does the heavy lifting for us instead of having to maintain get_access_token

api_client = PureCloudPlatformClientV2.api_client.ApiClient(host=host)
api_client = .get_client_credentials_token(
  client_id=client_id, client_secret=client_secret
)
auth_api = PureCloudPlatformClientV2.AuthorizationApi(api_client)
auth_perms = auth_api.get_authorization_permissions()
```