### PR TITLE
Separate deeply nested objects from conversations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-purecloud',
-      version='0.0.12',
+      version='0.0.13',
       description='Singer.io tap for extracting data from the Genesys Purecloud API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -33,7 +33,7 @@ from PureCloudPlatformClientV2.rest import ApiException as PureCloudApiException
 
 import tap_purecloud.schemas as schemas
 from tap_purecloud.websocket_helper import get_historical_adherence
-from tap_purecloud.util import safe_json_serialize_deserialize
+from tap_purecloud.util import safe_json_serialize_deserialize, handle_and_filter_page
 
 logger = singer.get_logger()
 
@@ -150,7 +150,7 @@ def fetch_all_analytics_records(get_records, body, entity_name, max_pages=None):
         yield results
 
 
-def parse_dates(record):
+def parse_dates(record: dict) -> dict:
     parsed = record.copy()
     for (k,v) in record.items():
         if isinstance(v, datetime.datetime):
@@ -158,7 +158,7 @@ def parse_dates(record):
     return parsed
 
 
-def handle_object(obj):
+def handle_object(obj: dict) -> dict:
     return parse_dates(obj.to_dict())
 
 
@@ -431,27 +431,6 @@ def sync_management_units(api_client: ApiClient, config):
         sync_historical_adherence(api_instance, config, unit_id, unit_users[unit_id], first_page)
 
 
-def handle_conversation(conversation_record):
-    conversation = handle_object(conversation_record)
-
-    participants = []
-    for participant_record in conversation_record.participants:
-        participants.append(handle_object(participant_record))
-
-        sessions = []
-        for session_record in participant_record.sessions:
-            sessions.append(handle_object(session_record))
-
-            segments = []
-            for segment_record in session_record.segments:
-                segments.append(handle_object(segment_record))
-
-            sessions[-1]['segments'] = segments
-        participants[-1]['sessions'] = sessions
-    conversation['participants'] = participants
-    return safe_json_serialize_deserialize(conversation)
-
-
 def sync_conversations(api_client: ApiClient, config):
     logger.info("Fetching conversations")
     api_instance = ConversationsApi(api_client)
@@ -474,12 +453,69 @@ def sync_conversations(api_client: ApiClient, config):
         body.order = "asc"
         body.orderBy = "conversationStart"
 
-        gen_conversations = fetch_all_analytics_records(api_instance.post_analytics_conversations_details_query, body, 'conversations')
-        stream_results(gen_conversations, handle_conversation, 'conversation', schemas.conversation, ['conversation_id'], first_page)
+        gen_conversations = fetch_all_analytics_records(
+            api_instance.post_analytics_conversations_details_query, body, 'conversations'
+        )
+
+        for conversation_page in gen_conversations:
+            conversations = handle_and_filter_page(conversation_page, handle_object)
+
+            # Handle deeply nested objects by separating them into different tables, keyed by the parent identifier
+            for i, conversation in enumerate(conversations):
+                conversation_id = conversation['conversation_id']
+                if first_page and i == 0:
+                    singer.write_schema('conversation', schemas.conversation, ['conversation_id'])
+
+                participants = conversation.pop('participants', [])
+                singer.write_record('conversation', conversation)
+                for j, participant in enumerate(participants):
+                    participant_id = participant['participant_id']
+                    participant['conversation_id'] = conversation_id
+                    write_conversation_participant_schema = first_page and i == 0 and j == 0
+                    if write_conversation_participant_schema:
+                        singer.write_schema(
+                            'conversation_participant',
+                            schemas.conversation_participant,
+                            ['conversation_id', 'participant_id']
+                        )
+
+                    sessions = participant.pop('sessions', [])
+                    singer.write_record('conversation_participant', participant)
+                    for k, session in enumerate(sessions):
+                        session_id = session['session_id']
+                        session['conversation_id'] = conversation_id
+                        session['participant_id'] = participant_id
+                        write_conversation_participant_session_schema = (
+                            first_page and i == 0 and j == 0 and k == 0
+                        )
+                        if write_conversation_participant_schema:
+                            singer.write_schema(
+                                'conversation_participant_session',
+                                schemas.conversation_participant_session,
+                                ['conversation_id', 'participant_id', 'session_id']
+                            )
+
+                        segments = session.pop('segments', [])
+                        singer.write_record('conversation_participant_session', session)
+                        for l, segment in enumerate(segments):
+                            segment['conversation_id'] = conversation_id
+                            segment['participant_id'] = participant_id
+                            segment['session_id'] = session_id
+
+                            write_conversation_participant_session_segment_schema = (
+                                first_page and i == 0 and j == 0 and k == 0 and l == 0
+                            )
+                            if write_conversation_participant_session_segment_schema:
+                                singer.write_schema(
+                                    'conversation_participant_session_segment',
+                                    schemas.conversation_participant_session_segment,
+                                    ['conversation_id', 'participant_id', 'session_id', 'segment_end']
+                                )
+                            singer.write_record('conversation_participant_session_segment', segment)
+
+            first_page = False
 
         sync_date = next_date
-        first_page = False
-
 
 def md5(s):
     hasher = hashlib.md5()
@@ -612,6 +648,7 @@ def do_sync(args):
 
     logger.info(f"Successfully got access token. Starting sync from {start_date}")
     
+    # https://developer.genesys.cloud/devapps/sdk/docexplorer/purecloudpython/
     sync_users(api_client)
     sync_groups(api_client)
     sync_locations(api_client)

--- a/tap_purecloud/schemas.py
+++ b/tap_purecloud/schemas.py
@@ -141,7 +141,28 @@ conversation = {
             'type': ['string', 'null'],
             'format': 'date-time',
             'description': 'end timestamp for the conversation',
-        }
+        },
+        "division_ids": {
+            "type": ["array", "null"],
+            "items": {
+                "type": "string"
+            }
+        },
+        "conversation_initiator": {
+            "type": ["string", "null"]
+        },
+        "media_stats_min_conversation_mos": {
+            "type": ["number", "null"]
+        },
+        "media_stats_min_conversation_r_factor": {
+            "type": ["number", "null"]
+        },
+        "originating_direction": {
+            "type": ["string", "null"]
+        },
+        "customer_participation": {
+            "type": ["boolean", "null"]
+        },
     }
 }
 
@@ -159,7 +180,13 @@ conversation_participant = {
         'participant_name': {
             'type': ['string', 'null'],
             'description': 'name for the participant'
-        }
+        },
+        "flagged_reason": {
+            "type": ["string", "null"]
+        },
+        "purpose": {
+            "type": ["string", "null"]
+        },
    }
 }
 
@@ -180,6 +207,24 @@ conversation_participant_session = {
         },
         'direction': {
             'type': 'string'
+        },
+        "media_type": {
+            "type": ["string", "null"]
+        },
+        "message_type": {
+            "type": ["string", "null"]
+        },
+        "outbound_campaign_id": {
+            "type": ["string", "null"]
+        },
+        "provider": {
+            "type": ["string", "null"]
+        },
+        "recording": {
+            "type": ["boolean", "null"]
+        },
+        "selected_agent_id": {
+            "type": ["string", "null"]
         }
     }
 }
@@ -208,7 +253,22 @@ conversation_participant_session_segment = {
             'type': ['string', 'null'],
             'format': 'date-time',
             'description': 'end datetime for the segment'
-        }
+        },
+        "queue_id": {
+            "type": ["string", "null"]
+        },
+        "group_id": {
+            "type": ["string", "null"]
+        },
+        "subject": {
+            "type": ["string", "null"]
+        },
+        "source_conversation_id": {
+            "type": ["string", "null"]
+        },
+        "source_session_id": {
+            "type": ["string", "null"]
+        },
     }
 }
 

--- a/tap_purecloud/schemas.py
+++ b/tap_purecloud/schemas.py
@@ -125,61 +125,6 @@ location = {
 }
 
 
-segment = {
-    'type': 'object',
-    'properties': {
-        'session_id': {
-            'type': 'string',
-            'description': 'id for the session',
-        },
-        'segment_start': {
-            'type': ['string', 'null'],
-            'format': 'date-time',
-            'description': 'start datetime for the segment',
-        },
-        'segment_end': {
-            'type': ['string', 'null'],
-            'format': 'date-time',
-            'description': 'end datetime for the segment',
-        }
-    }
-}
-
-
-session = {
-    'type': 'object',
-    'properties': {
-        'session_id': {
-            'type': 'string',
-            'description': 'id for the session',
-        },
-        'segments': {
-            'type': ['array', 'null'],
-            'items': segment
-        }
-    }
-}
-
-
-participant = {
-    'type': 'object',
-    'properties': {
-        'participant_id': {
-            'type': 'string',
-            'description': 'id for the participant',
-        },
-        'participant_name': {
-            'type': ['string', 'null'],
-            'description': 'name for the participant',
-        },
-        'sessions': {
-            'type': ['array', 'null'],
-            'items': session
-        }
-    }
-}
-
-
 conversation = {
     'type': 'object',
     'properties': {
@@ -196,15 +141,76 @@ conversation = {
             'type': ['string', 'null'],
             'format': 'date-time',
             'description': 'end timestamp for the conversation',
-        },
-
-        'participants': {
-            'type': ['array', 'null'],
-            'items': participant
         }
     }
 }
 
+conversation_participant = {
+   'type': 'object', 
+   'properties': {
+        'conversation_id': {
+            'type': 'string',
+            'description': 'id for the conversation'
+        },
+        'participant_id': {
+            'type': 'string',
+            'description': 'id for the participant'
+        },
+        'participant_name': {
+            'type': ['string', 'null'],
+            'description': 'name for the participant'
+        }
+   }
+}
+
+conversation_participant_session = {
+    'type': 'object', 
+    'properties': {
+        'conversation_id': {
+            'type': 'string',
+            'description': 'id for the conversation'
+        },
+        'participant_id': {
+            'type': 'string',
+            'description': 'id for the participant'
+        },
+        'session_id': {
+            'type': 'string',
+            'description': 'id for the session'
+        },
+        'direction': {
+            'type': 'string'
+        }
+    }
+}
+
+conversation_participant_session_segment = {
+    'type': 'object', 
+    'properties': {
+        'conversation_id': {
+            'type': 'string',
+            'description': 'id for the conversation'
+        },
+        'participant_id': {
+            'type': 'string',
+            'description': 'id for the participant'
+        },
+        'session_id': {
+            'type': 'string',
+            'description': 'id for the session'
+        },
+        'segment_start': {
+            'type': ['string', 'null'],
+            'format': 'date-time',
+            'description': 'start datetime for the segment'
+        },
+        'segment_end': {
+            'type': ['string', 'null'],
+            'format': 'date-time',
+            'description': 'end datetime for the segment'
+        }
+    }
+}
 
 user_state = {
     'type': 'object',

--- a/tap_purecloud/schemas/conversation.json
+++ b/tap_purecloud/schemas/conversation.json
@@ -13,51 +13,6 @@
             "type": ["string", "null"],
             "format": "date-time",
             "description": "end timestamp for the conversation"
-        },
-
-        "participants": {
-            "type": ["array", "null"],
-            "items": {
-                "type": "object",
-                "properties": {
-                    "participant_id": {
-                        "type": "string"
-                    },
-                    "participant_name": {
-                        "type": ["string", "null"]
-                    },
-                    "sessions": {
-                        "type": ["array", "null"],
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "session_id": {
-                                    "type": "string"
-                                },
-                                "segments": {
-                                    "type": ["array", "null"],
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "session_id": {
-                                                "type": "string"
-                                            },
-                                            "segment_start": {
-                                                "type": ["string", "null"],
-                                                "format": "date-time"
-                                            },
-                                            "segment_end": {
-                                                "type": ["string", "null"],
-                                                "format": "date-time"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/tap_purecloud/schemas/conversation.json
+++ b/tap_purecloud/schemas/conversation.json
@@ -13,6 +13,27 @@
             "type": ["string", "null"],
             "format": "date-time",
             "description": "end timestamp for the conversation"
+        },
+        "division_ids": {
+            "type": ["array", "null"],
+            "items": {
+                "type": "string"
+            }
+        },
+        "conversation_initiator": {
+            "type": ["string", "null"]
+        },
+        "media_stats_min_conversation_mos": {
+            "type": ["number", "null"]
+        },
+        "media_stats_min_conversation_r_factor": {
+            "type": ["number", "null"]
+        },
+        "originating_direction": {
+            "type": ["string", "null"]
+        },
+        "customer_participation": {
+            "type": ["boolean", "null"]
         }
     }
 }

--- a/tap_purecloud/schemas/custom_schemas/conversation_participant.json
+++ b/tap_purecloud/schemas/custom_schemas/conversation_participant.json
@@ -12,6 +12,12 @@
         "participant_name": {
             "type": ["string", "null"],
             "description": "name for the participant"
+        },
+        "flagged_reason": {
+            "type": ["string", "null"]
+        },
+        "purpose": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_purecloud/schemas/custom_schemas/conversation_participant.json
+++ b/tap_purecloud/schemas/custom_schemas/conversation_participant.json
@@ -1,0 +1,17 @@
+{
+    "type": "object",
+    "properties": {
+        "conversation_id": {
+            "type": "string",
+            "description": "id for the conversation"
+        },
+        "participant_id": {
+            "type": "string",
+            "description": "id for the participant"
+        },
+        "participant_name": {
+            "type": ["string", "null"],
+            "description": "name for the participant"
+        }
+    }
+}

--- a/tap_purecloud/schemas/custom_schemas/conversation_participant_session.json
+++ b/tap_purecloud/schemas/custom_schemas/conversation_participant_session.json
@@ -15,6 +15,24 @@
         },
         "direction": {
             "type": "string"
+        },
+        "media_type": {
+            "type": ["string", "null"]
+        },
+        "message_type": {
+            "type": ["string", "null"]
+        },
+        "outbound_campaign_id": {
+            "type": ["string", "null"]
+        },
+        "provider": {
+            "type": ["string", "null"]
+        },
+        "recording": {
+            "type": ["boolean", "null"]
+        },
+        "selected_agent_id": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_purecloud/schemas/custom_schemas/conversation_participant_session.json
+++ b/tap_purecloud/schemas/custom_schemas/conversation_participant_session.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "properties": {
+        "conversation_id": {
+            "type": "string",
+            "description": "id for the conversation"
+        },
+        "participant_id": {
+            "type": "string",
+            "description": "id for the participant"
+        },
+        "session_id": {
+            "type": "string",
+            "description": "id for the session"
+        },
+        "direction": {
+            "type": "string"
+        }
+    }
+}

--- a/tap_purecloud/schemas/custom_schemas/conversation_participant_session_segment.json
+++ b/tap_purecloud/schemas/custom_schemas/conversation_participant_session_segment.json
@@ -1,0 +1,27 @@
+{
+    "type": "object",
+    "properties": {
+        "conversation_id": {
+            "type": "string",
+            "description": "id for the conversation"
+        },
+        "participant_id": {
+            "type": "string",
+            "description": "id for the participant"
+        },
+        "session_id": {
+            "type": "string",
+            "description": "id for the session"
+        },
+        "segment_start": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "start datetime for the segment"
+        },
+        "segment_end": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "end datetime for the segment"
+        }
+    }
+}

--- a/tap_purecloud/schemas/custom_schemas/conversation_participant_session_segment.json
+++ b/tap_purecloud/schemas/custom_schemas/conversation_participant_session_segment.json
@@ -22,6 +22,21 @@
             "type": ["string", "null"],
             "format": "date-time",
             "description": "end datetime for the segment"
+        },
+        "queue_id": {
+            "type": ["string", "null"]
+        },
+        "group_id": {
+            "type": ["string", "null"]
+        },
+        "subject": {
+            "type": ["string", "null"]
+        },
+        "source_conversation_id": {
+            "type": ["string", "null"]
+        },
+        "source_session_id": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_purecloud/util.py
+++ b/tap_purecloud/util.py
@@ -11,3 +11,12 @@ def safe_json_serialize_deserialize(data: any, **kwargs) -> dict:
     """
     json_string = json.dumps(data, default=str, **kwargs)
     return json.loads(json_string)
+
+def handle_and_filter_page(page_of_records: list, handler: callable) -> list:
+    valid_records = []
+    for record in page_of_records:
+        data = handler(record)
+        if data is not None:
+            valid_records.append(data)
+
+    return valid_records


### PR DESCRIPTION
SQL query is basically impossible/expensive on conversation.participants, so separate them into different tables keyed by the parents external identifier(s).

Example conversation (imagine a query like get me all `direction`s in `conversation.participants[i].sessions[j])`:
```
{
  "conversation_id": "some_id",
  "participants": [
    {
      "purpose": "external",
      "team_id": null,
      "user_id": null,
      "participant_id": "participant_id",
      "participant_name": "participant_name",
      "sessions": [
        {
          "session_id": "session_id",
          ...
          "metrics": [...],
          ...
          "segments": [
            {
              "subject": null,
              ...
            },
            {
              "subject": null,
              ...
            },
            ...
          ],
          "direction": "inbound",
          ...
          "media_endpoint_stats": [
            {
              "codecs": ["audio/opus"],
              "min_mos": 4.8838737774617,
              "min_r_factor": 92.5077133178711,
              "max_latency_ms": 30,
              ...
            },
            ...
          ],
          "outbound_campaign_id": null,
          ...
        }
      ],
      ...
    },
    ...
  ]
}
```
We can now simply do a join on the tables via conversation_id:
```sql
select * from conversation c inner join conversation_participant_session cps on c.conversation_id = cps.conversation_id where direction = 'inbound';
``` 
