### PR TITLE
Separate user schedule shifts and activities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-purecloud',
-      version='0.0.14',
+      version='0.0.15',
       description='Singer.io tap for extracting data from the Genesys Purecloud API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -366,18 +366,18 @@ def sync_user_schedules(api_instance: WorkforceManagementApi, config, unit_id, u
             singer.write_record('user_schedule', user_schedule_)
             for i, shift in enumerate(shifts):
                 if first_page and i == 0 :
-                    singer.write_schema('user_schedule_shifts', schemas.user_schedule_shifts, ['user_id', 'id'])
+                    singer.write_schema('user_schedule_shift', schemas.user_schedule_shift, ['user_id', 'id'])
 
                 shift_id = shift["id"]
                 shift["user_id"] = user_id
                 activities = shift.pop('activities')
-                singer.write_record('user_schedule_shifts', shift)
+                singer.write_record('user_schedule_shift', shift)
                 for j, activity in enumerate(activities):
                     if first_page and i == 0 and j == 0:
-                        singer.write_schema('user_schedule_shift_activities', schemas.user_schedule_shift_activities, ['shift_id', 'user_id', 'start_date'])
+                        singer.write_schema('user_schedule_shift_activity', schemas.user_schedule_shift_activity, ['shift_id', 'user_id', 'start_date'])
                     activity["shift_id"] = shift_id
                     activity["user_id"] = user_id
-                    singer.write_record('user_schedule_shift_activities', activity)
+                    singer.write_record('user_schedule_shift_activity', activity)
 
             first_page = False
 

--- a/tap_purecloud/schemas.py
+++ b/tap_purecloud/schemas.py
@@ -408,7 +408,7 @@ user_schedule = {
     }
 }
 
-user_schedule_shifts = {
+user_schedule_shift = {
     'type': 'object',
     'properties': {
         "id": {
@@ -445,7 +445,7 @@ user_schedule_shifts = {
     }
 }
 
-user_schedule_shift_activities = {
+user_schedule_shift_activity = {
     'type': 'object',
     'properties': {
         "user_id": {

--- a/tap_purecloud/schemas.py
+++ b/tap_purecloud/schemas.py
@@ -358,31 +358,6 @@ management_unit_users = {
     }
 }
 
-user_schedule_shifts_activities = {
-    'type': 'object',
-    'properties': {
-        'activity_code_id': {
-            'type': 'string',
-            'description': 'id for the activity_code',
-        }
-    }
-}
-
-user_schedule_shifts = {
-    'type': 'object',
-    'properties': {
-        'start_date': {
-            'type': ['string', 'null'],
-            'format': 'date-time',
-            'description': 'date for the shift',
-        },
-        'activities': {
-            'type': ['array', 'null'],
-            'items': user_schedule_shifts_activities
-        }
-    }
-}
-
 user_schedule = {
     'type': 'object',
     'properties': {
@@ -395,10 +370,114 @@ user_schedule = {
             'format': 'date-time',
             'description': 'date for the sync',
         },
-        'shifts': {
-            'type': ['array', 'null'],
-            'items': user_schedule_shifts
+        "metadata": {
+            "type": ["object", "null"],
+            "properties": {
+                "version": {
+                    "type": "number"
+                },
+                "modified_by": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                    }
+                },
+                "date_modified": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "created_by": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                    }
+                },
+                "date_created": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "work_plan_id": {
+            "type": ["string", "null"]
         }
+    }
+}
+
+user_schedule_shifts = {
+    'type': 'object',
+    'properties': {
+        "id": {
+            "type": "string"
+        },
+        "user_id": {
+            "type": "string"
+        },
+        "length_in_minutes": {
+            "type": "number"
+        },
+        "week_schedule": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "week_date": {
+                    "type": "string"
+                }
+            }
+        },
+        'start_date': {
+            'type': ['string', 'null'],
+            'format': 'date-time',
+            'description': 'date for the shift',
+        },
+        "delete": {
+            "type": ["boolean", "null"]
+        },
+        "manually_edited": {
+            "type": ["boolean", "null"]
+        }
+    }
+}
+
+user_schedule_shift_activities = {
+    'type': 'object',
+    'properties': {
+        "user_id": {
+            "type": "string"
+        },
+        "shift_id": {
+            "type": "string"
+        },
+        'activity_code_id': {
+            'type': 'string',
+            'description': 'id for the activity_code',
+        },
+        "start_date": {
+            "type": "string",
+            "format": "date-time",
+        },
+        "length_in_minutes": {
+            "type": "number"
+        },
+        "description": {
+            "type": "string"
+        },
+        "counts_as_paid_time": {
+            "type": "boolean"
+        },
+        "is_dst_fallback": {
+            "type": ["boolean", "null"]
+        },
+        "time_off_request_id": {
+            "type": ["string", "null"]
+        }
+
     }
 }
 

--- a/tap_purecloud/schemas/custom_schemas/user_schedule_shift.json
+++ b/tap_purecloud/schemas/custom_schemas/user_schedule_shift.json
@@ -1,0 +1,36 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "user_id": {
+            "type": "string"
+        },
+        "length_in_minutes": {
+            "type": "number"
+        },
+        "week_schedule": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "week_date": {
+                    "type": "string"
+                }
+            }
+        },
+        "start_date": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "date for the shift"
+        },
+        "delete": {
+            "type": ["boolean", "null"]
+        },
+        "manually_edited": {
+            "type": ["boolean", "null"]
+        }
+    }
+}

--- a/tap_purecloud/schemas/custom_schemas/user_schedule_shift_activity.json
+++ b/tap_purecloud/schemas/custom_schemas/user_schedule_shift_activity.json
@@ -1,0 +1,34 @@
+{
+    "type": "object",
+    "properties": {
+        "user_id": {
+            "type": "string"
+        },
+        "shift_id": {
+            "type": "string"
+        },
+        "activity_code_id": {
+            "type": "string",
+            "description": "id for the activity_code"
+        },
+        "start_date": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "length_in_minutes": {
+            "type": "number"
+        },
+        "description": {
+            "type": "string"
+        },
+        "counts_as_paid_time": {
+            "type": "boolean"
+        },
+        "is_dst_fallback": {
+            "type": ["boolean", "null"]
+        },
+        "time_off_request_id": {
+            "type": ["string", "null"]
+        }
+    }
+}


### PR DESCRIPTION
Same idea, it's easier to look at the activities or shifts as separate tables instead of going through arrays of objects that have arrays of objects.