### PR TITLE
Fix pkey issues with shift and shift_actvity, also include week_schedule_id

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-purecloud',
-      version='0.0.16',
+      version='0.0.17',
       description='Singer.io tap for extracting data from the Genesys Purecloud API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -333,10 +333,13 @@ def sync_user_schedules(api_instance: WorkforceManagementApi, config, unit_id, u
 
     if first_page:
         singer.write_schema('user_schedule', schemas.user_schedule, ['start_date', 'user_id'])
-        singer.write_schema('user_schedule_shift', schemas.user_schedule_shift, ['user_id', 'id', 'week_schedule__id'])
+        singer.write_schema(
+            'user_schedule_shift', schemas.user_schedule_shift,
+            ['user_id', 'id', 'start_date', 'week_schedule__id']
+        )
         singer.write_schema(
             'user_schedule_shift_activity', schemas.user_schedule_shift_activity,
-            ['shift_id', 'user_id', 'start_date']
+            ['shift_id', 'user_id', 'start_date', 'week_schedule_id', 'activity_code_id']
         )
 
     entity_names = ('user_schedules', )
@@ -373,11 +376,13 @@ def sync_user_schedules(api_instance: WorkforceManagementApi, config, unit_id, u
             singer.write_record('user_schedule', user_schedule_)
             for shift in shifts:
                 shift_id = shift["id"]
+                shift_week_schedule_id = shift["week_schedule"]["id"]
                 shift["user_id"] = user_id
 
                 activities = shift.pop('activities')
                 singer.write_record('user_schedule_shift', shift)
                 for activity in activities:
+                    activity["week_schedule_id"] = shift_week_schedule_id
                     activity["shift_id"] = shift_id
                     activity["user_id"] = user_id
                     singer.write_record('user_schedule_shift_activity', activity)

--- a/tap_purecloud/schemas.py
+++ b/tap_purecloud/schemas.py
@@ -469,6 +469,7 @@ user_schedule_shift = {
         },
         "week_schedule": {
             "type": "object",
+            "description": "The schedule to which this shift belongs",
             "properties": {
                 "id": {
                     "type": "string"
@@ -499,6 +500,9 @@ user_schedule_shift_activity = {
             "type": "string"
         },
         "shift_id": {
+            "type": "string"
+        },
+        "week_schedule_id": {
             "type": "string"
         },
         'activity_code_id': {

--- a/tap_purecloud/schemas/custom_schemas/user_schedule_shift.json
+++ b/tap_purecloud/schemas/custom_schemas/user_schedule_shift.json
@@ -12,6 +12,7 @@
         },
         "week_schedule": {
             "type": "object",
+            "description": "The schedule to which this shift belongs",
             "properties": {
                 "id": {
                     "type": "string"

--- a/tap_purecloud/schemas/custom_schemas/user_schedule_shift_activity.json
+++ b/tap_purecloud/schemas/custom_schemas/user_schedule_shift_activity.json
@@ -7,6 +7,9 @@
         "shift_id": {
             "type": "string"
         },
+        "week_schedule_id": {
+            "type": "string"
+        },
         "activity_code_id": {
             "type": "string",
             "description": "id for the activity_code"


### PR DESCRIPTION
The start_date needs to be included in the pkey for both shift and shift_activity. Also includes week_schedule_id in shift_activity to tie back to the shift.

Going to drop shift and shift_activity tables and full sync them instead of altering constraints.