### PR TITLE
Remove activity_code_id from user_schedule_shift_activity_pkey, allow sync lookbacks

### DIFF
--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -346,7 +346,7 @@ def sync_user_schedules(api_instance: WorkforceManagementApi, config, unit_id, u
         )
         singer.write_schema(
             'user_schedule_shift_activity', schemas.user_schedule_shift_activity,
-            ['shift_id', 'user_id', 'start_date', 'week_schedule_id', 'activity_code_id']
+            ['shift_id', 'user_id', 'start_date', 'week_schedule_id']
         )
 
     entity_names = ('user_schedules', )

--- a/tap_purecloud/util.py
+++ b/tap_purecloud/util.py
@@ -20,3 +20,11 @@ def handle_and_filter_page(page_of_records: list, handler: callable) -> list:
             valid_records.append(data)
 
     return valid_records
+
+def safe_get(obj, default_value, *keys):
+    for key in keys:
+        try:
+            obj = obj[key]
+        except:
+            return default_value
+    return obj


### PR DESCRIPTION
activity_code_id shouldn't be included in the pkey since it can duplicate data / not update the right row.
allow sync offsets so that we don't have to sync each stream on the same sync date, but relative to the sync date.