### PR TITLE
respect catalog selections

### DIFF
--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -775,7 +775,7 @@ def do_sync(args):
         elif stream_name == 'management_unit':
             sync_management_units(api_client, config, stream.schema.to_dict())
         elif stream_name == 'conversation':
-            sync_conversations(api_client, stream.schema.to_dict())
+            sync_conversations(api_client, config, stream.schema.to_dict())
         elif stream_name == 'user_state':
             sync_user_state(api_client, config, stream.schema.to_dict())
 


### PR DESCRIPTION
Someone in the Meltano community posted [in slack](https://meltano.slack.com/archives/C01TCRBBJD7/p1683236775667699) about how this tap didnt respect their catalog selection criteria, this PR should add support for enabling/disabling streams and properties using meltano.

I dont have access to an account to test but I did validate that deselecting all streams passed with logs saying that they were skipped, then enabling one stream caused it to raise a 401 error due to invalid credentials.


@vorpal56 @kyuhanpathlight I know this is a fork of the original tap but it looks like this repo has been the most active and has seen the most recent commits so thought it was appropriate to create the PR here 😄 , let me know what you think!