### PR TITLE
[BUG] historical_adherence record outputted before schema 

### DIFF
--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -496,6 +496,7 @@ def sync_management_units(api_client: ApiClient, config):
 
     # first, write out the units
     mgmt_units = stream_results(gen_units, ('entities', ), lambda x: x, 'management_unit', schemas.management_unit, ['id'], True)
+    should_output_schema = True
 
     for i, unit in enumerate(mgmt_units):
         logger.info("Syncing mgmt unit {} of {}".format(i + 1, len(mgmt_units)))
@@ -519,10 +520,11 @@ def sync_management_units(api_client: ApiClient, config):
             continue
 
         user_ids = [user['user_id'] for user in users]
-        sync_user_schedules(api_instance, config, unit_id, user_ids, first_page)
+        sync_user_schedules(api_instance, config, unit_id, user_ids, should_output_schema)
 
         unit_users = get_user_unit_mapping(users)
-        sync_historical_adherence(api_instance, config, unit_id, unit_users[unit_id], first_page)
+        sync_historical_adherence(api_instance, config, unit_id, unit_users[unit_id], should_output_schema)
+        should_output_schema = False
 
 
 def sync_conversations(api_client: ApiClient, config):

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -496,6 +496,8 @@ def sync_management_units(api_client: ApiClient, config):
 
     # first, write out the units
     mgmt_units = stream_results(gen_units, ('entities', ), lambda x: x, 'management_unit', schemas.management_unit, ['id'], True)
+    # first records may not be on first page, use separate variable to track the first time we have users and records 
+    # for either historical_adherence or user_schedules schemas to ensure schema is properly outputted before records
     should_output_schema = True
 
     for i, unit in enumerate(mgmt_units):


### PR DESCRIPTION
JIRA: https://pathlighthq.atlassian.net/browse/FUJ-5496

`sync_historical_adherence` uses the last parameter (boolean) to determine whether or not to output the schema before syncing records. The error we were getting was indicating that somehow we were ending up with historical_adherence records before the schema was ever outputted. Looking at the logic, we can see that this scenario may occur if/when users is empty on the first page (we skip the call to sync_historical_adherence) but then not on the following pages.

The fix here is to just use a separate variable to track whether or not the schema has been outputted rather than relying on the assumption that there will always be users on the first page (or the assumption that if there aren't then there are no records across the remaining pages).
